### PR TITLE
Shadow-cljs preload

### DIFF
--- a/src-inst/flow_storm/preload.cljs
+++ b/src-inst/flow_storm/preload.cljs
@@ -1,0 +1,4 @@
+(ns flow-storm.preload
+  (:require [flow-storm.api :as fs-api]))
+
+(fs-api/connect)

--- a/src-inst/flow_storm/preload.cljs
+++ b/src-inst/flow_storm/preload.cljs
@@ -1,4 +1,4 @@
 (ns flow-storm.preload
   (:require [flow-storm.api :as fs-api]))
 
-(fs-api/connect)
+(fs-api/remote-connect)


### PR DESCRIPTION
Same fix as for previous version 😄 

Enables shadow-cljs integration without having to provide additional source code or REPL interaction.