### PR TITLE
add auto dark mode support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src-inst" "src-dbg" "src-shared" "resources" ]
+ :mvn/repos {"jitpack" {:url "https://jitpack.io"}}
  :deps {
         ;; Remote debugging
         org.java-websocket/Java-WebSocket {:mvn/version "1.5.2"}
@@ -29,7 +30,11 @@
 
                               ;; Icon fonts
                               org.kordamp.ikonli/ikonli-javafx {:mvn/version "11.5.0"}
-                              org.kordamp.ikonli/ikonli-materialdesign-pack {:mvn/version "11.5.0"}}}
+                              org.kordamp.ikonli/ikonli-materialdesign-pack {:mvn/version "11.5.0"}
+                              
+                              ;; Dark mode
+                              com.github.Dansoftowner/jSystemThemeDetector {:mvn/version "3.8"}}}
+
 
            :inst {:extra-paths ["src-inst" "src-shared"]
                   :extra-deps {;; Namespaces instrumentation

--- a/docs/user_guide.adoc
+++ b/docs/user_guide.adoc
@@ -521,14 +521,14 @@ clj -Sdeps '{:deps {org.clojure/clojurescript {:mvn/version "1.11.57"} com.githu
 == Styling and theming
 
 All functions that start the debugger ui (`flow-storm.api/local-connect`, `flow-storm.debugger.main/start-debugger`) accept a map
-with the `:styles` keyword. If it points to a css file it will be used to overwrite the default styles, in case you want to change
-colors, make your fonts bigger, etc.
+with the `:styles` and `:theme` keywords. If `:styles` points to a css file it will be used to overwrite the default styles, in case you 
+want to change colors, make your fonts bigger, etc. `:theme` could be one of `:auto` (default), `:light`, `:dark`.
 
 Like this :
 
 [,clojure]
 ----
-user> (local-connect {:styles "~/.flow-storm/big-fonts.css"})
+user> (local-connect {:styles "~/.flow-storm/big-fonts.css" :theme :dark})
 ----
 
 You can overwrite all the styles defined here https://github.com/jpmonettas/flow-storm-debugger/blob/master/resources/styles.css

--- a/docs/user_guide.html
+++ b/docs/user_guide.html
@@ -1537,8 +1537,8 @@ run you original command.</p>
 <h3 id="_styling_and_theming"><a class="anchor" href="#_styling_and_theming"></a><a class="link" href="#_styling_and_theming">7. Styling and theming</a></h3>
 <div class="paragraph">
 <p>All functions that start the debugger ui (<code>flow-storm.api/local-connect</code>, <code>flow-storm.debugger.main/start-debugger</code>) accept a map
-with the <code>:styles</code> keyword. If it points to a css file it will be used to overwrite the default styles, in case you want to change
-colors, make your fonts bigger, etc.</p>
+with the <code>:styles</code>  and `:theme` keywords. If `:styles` points to a css file it will be used to overwrite the default styles, in case you 
+want to change colors, make your fonts bigger, etc. `:theme` could be one of `:auto` (default), `:light`, `:dark`.</p>
 </div>
 <div class="paragraph">
 <p>Like this :</p>

--- a/resources/styles_dark.css
+++ b/resources/styles_dark.css
@@ -1,0 +1,185 @@
+@font-face {
+    src: url('fonts/Roboto-Light.ttf');
+}
+
+@font-face {
+    src: url('fonts/Roboto-Medium.ttf');
+}
+
+.root {
+        -fx-base: rgb(50, 50, 50);
+        -fx-background: rgb(50, 50, 50);
+        -fx-control-inner-background:  rgb(50, 50, 50);
+}
+
+.separator-label {
+    -fx-text-fill: orange;
+}
+
+.main-pane {
+	-fx-font-family: 'Roboto Medium';
+	-fx-font-size: 12;
+}
+
+.tab .ikonli-font-icon {
+	-fx-font-size: 15;
+        -fx-icon-color: white;
+        -fx-background-color: linear-gradient(to top, -fx-base, derive(-fx-base,30%));
+}
+.vertical-tab:selected {
+	-fx-background-color: #4743ba;
+}
+
+.vertical-tab:selected .tab-label { 
+	-fx-text-fill: white;
+}
+
+.button {
+        -fx-background-color: transparent;
+}
+
+.button:hover {
+        -fx-background-color: -fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, -fx-body-color;
+        -fx-color: -fx-hover-base;
+}
+
+.button:focused { /* this is so buttons doesn't look smaller when they are focused */
+	-fx-background-insets: 0 0 -1 0;
+}
+
+.button .ikonli-font-icon {
+	-fx-icon-color: white;
+}
+
+.text-field {
+    -fx-prompt-text-fill: white;
+}
+
+.tree-search {
+	-fx-background-insets: 1 0 1 0;
+}
+
+.form-pane {
+	-fx-background-color: #2f353b;
+}
+
+.label.defmethod {
+	-fx-text-fill: #9c0084;
+}
+
+.label.defn {
+	-fx-text-fill: #FFF;
+}
+
+.label.extend-type {
+	-fx-text-fill: #369658;
+}
+
+.label.extend-protocol {
+	-fx-text-fill: #369658;
+}
+
+.label.anonymous {
+	-fx-text-fill: #FFF;
+}
+
+.label.fn-ns {
+	-fx-text-fill: #999;
+}
+
+.label.fn-args {
+	-fx-text-fill: #777;
+}
+
+.code-token {
+	-fx-font-family: 'monospaced';
+	-fx-font-size: 13;
+	-fx-fill: #FFF;
+}
+.code-token.executing {
+        -fx-stroke: #60d61b;
+	-fx-font-size: 15;
+	-fx-fill: #60d61b;
+	-fx-stroke-width: 1;
+}
+
+.code-token.interesting {
+	-fx-fill: #de00c0;
+	-fx-cursor: hand;
+	-fx-font-weight: bold;
+}
+
+.form-pane {
+	-fx-padding: 10;
+}
+
+.thread-controls-pane {
+	-fx-background-color: #3f474f;
+	-fx-padding: 10;
+}
+
+.trace-position-box {
+	-fx-alignment: center;
+}
+
+.button.def-btn {
+	-fx-font-size: 10;
+}
+
+/*****************/
+/* Browser stuff */
+/*****************/
+
+.label.browser-fn-fq-name {
+	-fx-font-weight: bold;
+	-fx-font-size: 15;
+	-fx-text-fill: #336699;
+	-fx-padding: 10;
+}
+
+.browser-fn-args-box {
+	-fx-padding: 10;
+}
+
+.label.browser-fn-attr {
+	-fx-padding: 10;
+}
+
+.button.browser-instrument-btn {
+	-fx-background-color: #336699;
+        -fx-text-fill: white;
+	-fx-font-size: 10;
+	-fx-display: none;
+	visibility: hidden;
+}
+
+.button.browser-instrument-btn.enable {
+	visibility: visible;
+}
+
+.browser-instr-del-btn {
+	-fx-background-color: #336699;
+        -fx-text-fill: white;
+	-fx-font-size: 10;
+}
+
+.browser-instr-type-lbl {
+	-fx-text-fill: #919191;
+}
+
+.browser-instr-tools-box {
+	-fx-padding: 10;
+}
+
+.button {
+	-fx-background-color: #336699;
+        -fx-text-fill: white;    
+}
+
+.main-bottom-bar-box {
+	-fx-background-color: #ddd;
+}
+
+.button.reload-tree-btn {
+	-fx-background-color: #919191;
+}

--- a/src-dbg/flow_storm/debugger/ui/state_vars.clj
+++ b/src-dbg/flow_storm/debugger/ui/state_vars.clj
@@ -5,6 +5,7 @@
 (defonce ctx-menu nil)
 (defonce stage nil)
 (defonce scene nil)
+(defonce dark-listener nil)
 
 (def long-running-task-thread (atom nil))
 

--- a/src-dev/dev.clj
+++ b/src-dev/dev.clj
@@ -95,7 +95,7 @@
   (self-instrument)
   (run-test-instrumented)
 
-  (fs-api/local-connect)
+  (fs-api/local-connect {:theme :light})
 
   #trace
   (defn some-calculation [a]


### PR DESCRIPTION
fix https://github.com/jpmonettas/flow-storm-debugger/issues/22

Demo video https://clojurians.slack.com/files/UL05W6AEM/F03RQRX7L1Z/screen_recording_2022-07-31_at_22.24.10.mov

Tested only on OSX (but I think it should work on windows and gnome as [this lib](https://github.com/Dansoftowner/jSystemThemeDetector/tree/master/src/main/java/com/jthemedetecor) says). 

Auto mode is set by default. To force particular theme, pass `:theme` as one of `:light`, `:dark`, `:auto`.
```clojure
(fs-api/local-connect {:theme :light})
```